### PR TITLE
Fix context typing for GET handler

### DIFF
--- a/src/app/api/factories/[name]/route.ts
+++ b/src/app/api/factories/[name]/route.ts
@@ -3,10 +3,10 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(
   req: NextRequest,
-  context: { params: Promise<{ name: string }> }
+  context: { params: { name: string } }
 ) {
   try {
-    const { name } = await context.params
+    const { name } = context.params
     const decodedName = decodeURIComponent(name)
 
     const [factoryRows] = await db.query(


### PR DESCRIPTION
## Summary
- change GET handler parameter type to `context: { params: { name: string } }`
- remove unnecessary `await`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6841898f761c8322923cd24e881b0168